### PR TITLE
Removes `prettier` option `endOfLine`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 	"prettier": {
 		"arrowParens": "always",
 		"bracketSpacing": false,
-		"endOfLine": "lf",
 		"semi": true,
 		"singleQuote": true,
 		"useTabs": true


### PR DESCRIPTION
It's better to use the default and let `git` handle setting the EOL of files.